### PR TITLE
add simple event-loop test

### DIFF
--- a/test/uv/embedded-event-loop.kk
+++ b/test/uv/embedded-event-loop.kk
@@ -1,0 +1,8 @@
+import std/async/async
+import uv/event-loop
+
+fun main()
+  with default-event-loop
+  with async/handle
+  try { wait(0.1) } fn(_) (impossible("exception in wait")) // TODO this seems unnecessary
+  println("hello, world!")

--- a/test/uv/event-loop-test.kk
+++ b/test/uv/event-loop-test.kk
@@ -1,0 +1,32 @@
+import std/test
+import std/async/async
+import uv/event-loop
+import std/os/process
+
+fun expect-contains(s: string, f: () -> io string)
+  val result = f()
+  expect(True, details = result ++ " contains " ++ s) { result.contains(s) }
+
+fun main(): io-noexn ()
+  with default-event-loop
+  with async/handle
+  run-tests(suite)
+
+fun suite(): <async,test<<io,async>>> ()
+  effectful-test("test")
+    expect(1) {
+      wait(0.1)
+      1
+    }
+
+  // catches errors during event loop finalization
+  effectful-test("successful process")
+    // TODO: use async process once that's stable
+    expect(0) {
+      run-system("koka -e test/uv/embedded-event-loop.kk")
+    }
+
+  // TODO: this doesn't fail, even though the above exit code is reported as 1
+  // effectful-test("successful process (output)")
+  //   expect-contains("hello, world!")
+  //     run-system-read("koka -e test/uv/embedded-event-loop.kk").untry


### PR DESCRIPTION
For me this fails with:

```
command: /Users/tcuthbertson/.koka/v3.2.3/clang-debug-c99c1/test_uv_embedded_dash_event_dash_loop__main
Expectation failed (test/uv/event-loop-test:25)t
expected: 0
     got: 1
- failed
    # test/uv/event-loop-test:23

1 failures, 1 successes

Failed tests:
 - successful process
```

Seems like maybe the event loop teardown code segfaults? Here's the backtrace I get out of `lldb`:

```
$ lldb /Users/tcuthbertson/.koka/v3.2.3/clang-debug-7c99c1/test_uv_embedded_dash_event_dash_loop__main
(lldb) target create "/Users/tcuthbertson/.koka/v3.2.3/clang-debug-7c99c1/test_uv_embedded_dash_event_dash_loop__main"
Current executable set to '/Users/tcuthbertson/.koka/v3.2.3/clang-debug-7c99c1/test_uv_embedded_dash_event_dash_loop__main' (arm64).

(lldb) process launch
Process 94927 launched: '/Users/tcuthbertson/.koka/v3.2.3/clang-debug-7c99c1/test_uv_embedded_dash_event_dash_loop__main' (arm64)
hello, world!
Process 94927 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0xdfdfdfdfdfdfe017)
    frame #0: 0x0000000100147020 test_uv_embedded_dash_event_dash_loop__main`uv_loop_close(loop=0x0000020000090400) at uv-common.c:885:9
Target 0: (test_uv_embedded_dash_event_dash_loop__main) stopped.

(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0xdfdfdfdfdfdfe017)
  * frame #0: 0x0000000100147020 test_uv_embedded_dash_event_dash_loop__main`uv_loop_close(loop=0x0000020000090400) at uv-common.c:885:9
    frame #1: 0x0000000100140650 test_uv_embedded_dash_event_dash_loop__main`kk_uv_loop_close(_ctx=<unavailable>) at uv_event_dash_loop.c:75:3 [opt] [inlined]
    frame #2: 0x0000000100140648 test_uv_embedded_dash_event_dash_loop__main`kk_async_loop_close(_ctx=<unavailable>) at uv_event_dash_loop.c:118:12 [opt] [inlined]
    frame #3: 0x0000000100140648 test_uv_embedded_dash_event_dash_loop__main`kk_uv_event_dash_loop_close_loop(_ctx=<unavailable>) at uv_event_dash_loop.c:169:3 [opt] [inlined]
    frame #4: 0x0000000100140648 test_uv_embedded_dash_event_dash_loop__main`kk_uv_event_dash_loop_handle_loop_fun90(_fself=<unavailable>, _ctx=<unavailable>) at uv_event_dash_loop.c:330:3 [opt]
    frame #5: 0x000000010013f634 test_uv_embedded_dash_event_dash_loop__main`kk_std_core_hnd__open_none0(f=<unavailable>, _ctx=0x0000020000010200) at std_core_hnd.h:1281:16 [opt] [inlined]
    frame #6: 0x000000010013f60c test_uv_embedded_dash_event_dash_loop__main`kk_uv_event_dash_loop_handle_loop(action=<unavailable>, _ctx=0x0000020000010200) at uv_event_dash_loop.c:348:23 [opt]
    frame #7: 0x000000010013f91c test_uv_embedded_dash_event_dash_loop__main`kk_uv_event_dash_loop_default_event_loop(action=<unavailable>, _ctx=<unavailable>) at uv_event_dash_loop.c:405:12 [opt] [artificial]
    frame #8: 0x00000001001414f8 test_uv_embedded_dash_event_dash_loop__main`kk_test_uv_embedded_dash_event_dash_loop_main(_ctx=<unavailable>) at test_uv_embedded_dash_event_dash_loop.c:324:21 [opt]
    frame #9: 0x0000000100142794 test_uv_embedded_dash_event_dash_loop__main`kk_test_uv_embedded_dash_event_dash_loop__main__main(_ctx=0x0000020000010200) at test_uv_embedded_dash_event_dash_loop__main.h:58:3 [opt] [inlined]
    frame #10: 0x000000010014278c test_uv_embedded_dash_event_dash_loop__main`main_run(_ctx=0x0000020000010200) at test_uv_embedded_dash_event_dash_loop__main.c:113:3 [opt] [inlined]
    frame #11: 0x000000010014278c test_uv_embedded_dash_event_dash_loop__main`main(argc=<unavailable>, argv=<unavailable>) at test_uv_embedded_dash_event_dash_loop__main.c:131:3 [opt]
    frame #12: 0x0000000181582b98 dyld`start + 6076
```