### PR TITLE
Add process module

### DIFF
--- a/std/async/process.kk
+++ b/std/async/process.kk
@@ -1,0 +1,215 @@
+module std/async/process
+
+// Note: importing std/async causes clash with set-timeout / clear-timeout
+import std/async/async
+import uv/process
+import uv/signal
+import std/num/int32
+import std/num/int64
+import std/time/duration
+
+// high-level wrappers for uv/process
+// TODO: support passing in pipes, and using strings for input/output
+
+// A command specification, which can be used to spawn a process
+pub struct command
+  exe: string
+  args: list<string>
+  input: child-input
+  output: child-output
+
+pub fun command(
+  exe,
+  args: list<string> = [],
+  input: child-input = default,
+  output: child-output = default
+  ) Command(exe, args, input, output)
+
+pub fun command/show(command: command)
+  "command("++command.exe.show++", "++command.args.show++")"
+
+pub type child-input
+  Ignore-input
+  Inherit-input
+
+pub val input/default = Inherit-input
+pub val input/inherit: child-input = Inherit-input
+pub val input/ignore: child-input = Ignore-input
+
+type child-output-stream
+  Ignore-output
+  Inerhit-output
+  // Capture-output
+  // Output-to(pipe)
+
+type child-output
+  // Capture-merged
+  // Merge-output-to(pipe)
+  Split(stdout: child-output-stream, stderr: child-output-stream)
+
+pub val output/default: child-output = Split(Inerhit-output, Inerhit-output)
+pub val output/inherit: child-output = Split(Inerhit-output, Inerhit-output)
+pub val output/ignore: child-output = Split(Ignore-output, Ignore-output)
+// pub val const/capture-stdout: child-output = Split(Capture-output, Inerhit-output)
+// pub val const/capture-merged: child-output = Capture-merged
+
+// fun update/capture-stdout(o: child-output): child-output
+//   match o
+//     Capture-merged -> Capture-merged // TODO error?
+//     Split(_, stderr) -> Split(Capture-output, stderr)
+
+fun update/ignore-stderr(o: child-output): child-output
+  match o
+    // Capture-merged -> Split(Capture-output, Ignore-output)
+    Split(stdout, _) -> Split(stdout, Ignore-output)
+
+abstract struct process
+  internal: uv-process
+  exit-p: promise<exit>
+
+pub type exit
+  Exit-code(code: int)
+  Exit-signal(signal: int)
+
+pub fun exit/show(exit: exit)
+  match exit
+    Exit-code(i) -> "status:" ++ i.show
+    Exit-signal(s) -> "signal:" ++ s.show
+
+pub fun exit/ok(exit: exit)
+  match exit
+    Exit-code(0) -> True
+    _ -> False
+
+pub fun exit/failed(exit: exit) !exit.ok
+
+pub fun exit/check-exit(exit: exit): exn ()
+  if exit.failed then
+    throw("Command failed (" ++ show(exit) ++ ")")
+
+pub fun exit/(==)(a: exit, b: exit): div bool
+  match (a,b)
+    (Exit-code(a), Exit-code(b)) -> a == b
+    (Exit-signal(a), Exit-signal(b)) -> a == b
+    _ -> False
+
+fun stdio-stream-of-output(output: child-output-stream, inherit-fd)
+  match output
+    Ignore-output -> Stream-ignore
+    Inerhit-output -> Stream-fd(inherit-fd)
+    // Capture-output -> impossible("TODO")
+
+pub type kill-strategy
+  Signal-once(signal: int32)
+  Signal-repeat(signal: int32, wait: duration)
+  Signal-escalate(wait: duration)
+
+pub val kill-strategy/default = Signal-escalate(20.seconds)
+
+// TODO: move into async?
+// Without cancelation, this likely causes a memory leak
+// because it is never resolved.
+fun never(): asyncx a
+  await0 fn(cb) ()
+  impossible("impossible: never() resumed")
+
+fun do-kill(process: process, strategy: kill-strategy): <io,async> ()
+  match strategy
+    Signal-once -> process.signal(sSIGINT)
+    Signal-repeat(signum, wait-time) ->
+      while { True }
+        process.signal(signum)
+        // TODO: async/wait should work?
+        duration/wait(wait-time)
+    Signal-escalate(wait-time) ->
+      [sSIGINT, sSIGQUIT, sSIGKILL].foreach fn(signum)
+        process.signal(signum)
+        duration/wait(wait-time)
+
+// kill a process and wait for it to end
+pub fun kill(process: process, strategy: kill-strategy = default): <io,async> exit
+  fun perform()
+    do-kill(process, strategy)
+    never()
+  firstof(perform, { process.await })
+
+// send a signal to a process and immeditately return.
+// See `kill` for a variant which waits for the process to exit
+pub fun signal(process: process, sig: int32): <io,async> ()
+  uv/process/signal(process.internal, sig)
+
+fun finalize-process(p, strategy: kill-strategy)
+  match p.exit-p.try-await
+    Just(_) -> ()
+    Nothing ->
+      p.kill(strategy)
+      ()
+
+pub fun only/run(
+  command: command,
+  // optional args
+  kill-strategy: kill-strategy = default
+  ): <io,async|e> ()
+  run(
+    command,
+    kill-strategy=kill-strategy,
+    action=fn(_) ()
+  )
+
+pub fun run(
+  command: command,
+  action: (process) -> <io,async|e> a,
+  // optional args
+  check-exit: bool = True,
+  kill-strategy: kill-strategy = default
+  ): <io,async|e> a
+  val uv-stdin = match command.input
+    Ignore-input -> Stream-ignore
+    Inherit-input -> Stream-fd(0.int32)
+
+  val (uv-stdout, uv-stderr) = match command.output
+    Split(out, err) ->
+      (
+        stdio-stream-of-output(out, 1.int32),
+        stdio-stream-of-output(err, 2.int32)
+      )
+
+  val exit-p = promise()
+  fun on-exit(status: int64, signal: int32) ->
+    val sig = signal.int
+    val exit = if sig != 0 then Exit-signal(sig) else Exit-code(status.int)
+    // TODO can we make this not throw?
+    try {
+      val _: bool = exit-p.try-resolve-io(exit)
+      ()
+    } fn(ex)
+      impossible("RESOLVE: " ++ ex.show)
+
+  val uv-cmd = Uv-command(
+    file = command.exe,
+    args = command.args,
+    stdin = uv-stdin,
+    stdout = uv-stdout,
+    stderr = uv-stderr
+  )
+  val uv-process = spawn(uv-cmd, on-exit)
+  val process = Process(uv-process, exit-p)
+  with finally
+    // this finalizer will kill the process,
+    // but only if it hasn't already ended
+    // (which the success path will wait for)
+    finalize-process(process, kill-strategy)
+
+  val result = action(process)
+
+  // if block succeeded, wait for process and check for failure
+  val exit = process.await
+  if check-exit then
+    exit/check-exit(exit)
+  result
+
+pub fun await(process: process): <io,async> exit
+  process.exit-p.await
+
+pub fun pid(process: process): <io-noexn> int
+  process.internal.uv/process/pid.int

--- a/test/std/async/process-test.kk
+++ b/test/std/async/process-test.kk
@@ -1,0 +1,53 @@
+import uv/event-loop
+import std/num/int32
+import std/async/process
+import std/test
+import std/async/async
+
+fun main()
+  with default-event-loop
+  with async/handle
+  run-tests(suite)
+
+fun error-message(action: () -> <exn|e> a): e maybe<string>
+  match action.try
+    Error(ex) -> Just(ex.message)
+    Ok(_) -> Nothing
+
+fun expect-error-message(message, action)
+  expect(Just(message)) { error-message(action) }
+
+fun expect-process-finished(process)
+  expect-error-message("no such process") { process.signal(0.int32) }
+
+fun suite()
+  effectful-test("success")
+    expect(())
+      command("true", []).run()
+    wait(0.2)
+
+  effectful-test("failure")
+    expect-error-message("Command failed (status:1)")
+      command("false", []).run()
+    wait(0.2)
+
+  effectful-test("allowable failure")
+    expect(Exit-code(1))
+      command("false", []).run(check-exit = False) fn(p)
+        p.await()
+    wait(0.2)
+
+  effectful-test("`run` does not return until the process ends")
+    val p = command("sleep", ["0.3"]).run(fn(p) p)
+    expect-process-finished(p)
+    wait(0.2)
+
+  effectful-test("`run` kills the process when the block throws")
+    var process := Nothing
+    val errmsg = "error in block"
+    expect-error-message(errmsg)
+      command("sleep", ["100"]).run fn(p)
+        process := Just(p)
+        throw(errmsg)
+    expect-process-finished(process.unjust)
+    wait(0.2)

--- a/uv/inline/process.c
+++ b/uv/inline/process.c
@@ -1,0 +1,156 @@
+#include "uv_process.h"
+
+#define kk_unbox_process_borrowed(kk_process) \
+  (kk_uv_process_wrapper_t*)kk_cptr_raw_unbox_borrowed(kk_process.internal, _ctx)
+
+typedef struct kk_uv_process_wrapper_s {
+  uv_process_t process;
+  kk_function_t on_exit;
+  kk_uv_process__uv_process kprocess; // the boxed version of this struct, required to correctly drop
+} kk_uv_process_wrapper_t;
+
+// TODO: move into utils?
+// make a copy of a string (and terminate it with a null byte)
+char* kk_string_cstr_alloc(kk_string_t str, kk_context_t* _ctx) {
+  kk_ssize_t len;
+  const char* slice = kk_string_cbuf_borrow(str, &len, _ctx);
+  char* result = kk_malloc(len + 1, _ctx);
+  memcpy(result, slice, len);
+  result[len] = '\0';
+  return result;
+}
+
+// TODO: move into utils?
+// Helper function to convert Koka list<string> to null-terminated C char** array.
+static char** kk_list_string_to_nt_carray_borrow(kk_std_core_types__list list, kk_context_t* _ctx) {
+  kk_std_core_types__list_dup(list, _ctx);
+  kk_integer_t klist_len = kk_std_core_list_length(list, _ctx);
+  int list_len = kk_integer_clamp32(klist_len, _ctx);
+
+  char** arr = (char**)kk_malloc((list_len + 1) * sizeof(char*), _ctx);
+
+  kk_std_core_types__list current = list;
+  for (int i = 0; i < list_len; i++){
+    struct kk_std_core_types_Cons* cons = kk_std_core_types__as_Cons(current, _ctx);
+    kk_string_t str = kk_string_unbox(cons->head);
+    arr[i] = kk_string_cstr_alloc(str, _ctx);
+    current = cons->tail;
+  }
+  arr[list_len] = NULL;
+  return arr;
+}
+
+// TODO: move into utils?
+// Note: `arr` must be null terminated
+static void kk_free_nt_carray(char** arr, kk_context_t* _ctx) {
+  if (arr == NULL) return;
+  char** current = arr;
+  while(*current != NULL) {
+    kk_free(*current, _ctx);
+    current += 1;
+  }
+  kk_free(arr, _ctx);
+}
+
+void kk_uv_process_wrapper_free(void *p, kk_block_t *block, kk_context_t *_ctx) {
+  kk_uv_process_wrapper_t* wrapper = (kk_uv_process_wrapper_t*)p;
+  kk_function_drop(wrapper->on_exit, _ctx);
+  kk_free(wrapper, _ctx);
+}
+
+static void kk_uv_process_on_close(uv_handle_t* process) {
+  kk_uv_process_wrapper_t* wrapper = (kk_uv_process_wrapper_t*)process;
+  kk_uv_process__uv_process_drop(wrapper->kprocess, kk_get_context());
+}
+
+static void kk_uv_process_exit_callback(uv_process_t* process, int64_t exit_status, int term_signal) {
+  kk_context_t* _ctx = kk_get_context();
+  kk_uv_process_wrapper_t* wrapper = (kk_uv_process_wrapper_t*)process;
+  kk_function_call(kk_unit_t, (kk_function_t, int64_t, int32_t, kk_context_t*),
+                   wrapper->on_exit,
+                   (wrapper->on_exit, exit_status, (int32_t)term_signal, _ctx),
+                   _ctx);
+
+  uv_close((uv_handle_t*)process, kk_uv_process_on_close);
+}
+
+static uv_stdio_container_t kk_convert_to_stdio_container(
+  kk_uv_process__stdio_stream stream,
+  kk_context_t* _ctx
+) {
+  uv_stdio_container_t result = {0};
+  if (kk_uv_process_is_stream_ignore(stream, _ctx)) {
+    result.flags = UV_IGNORE;
+  } else if (kk_uv_process_is_stream_fd(stream, _ctx)) {
+    result.flags = UV_INHERIT_FD;
+    struct kk_uv_process_Stream_fd* stream_fd = kk_uv_process__as_Stream_fd(stream, _ctx);
+    result.data.fd = stream_fd->fd;
+  } else {
+    kk_fatal_error(EINVAL, "unknown stream type\n");
+  }
+  return result;
+}
+
+static kk_std_core_exn__error kk_uv_proc_spawn_c(
+  kk_uv_process__uv_command kk_command,
+  kk_function_t on_complete,
+  kk_context_t* _ctx
+) {
+  struct kk_uv_process_Uv_command* command = kk_uv_process__as_Uv_command(kk_command, _ctx);
+
+  uv_process_options_t options = {0};
+
+  kk_ssize_t file_len;
+  options.file = kk_string_cstr_alloc(command->file, _ctx);
+
+  options.args = kk_list_string_to_nt_carray_borrow(command->args, _ctx);
+  
+  options.stdio_count = 3;
+  uv_stdio_container_t child_stdio[3];
+  child_stdio[0] = kk_convert_to_stdio_container(command->stdin, _ctx);
+  child_stdio[1] = kk_convert_to_stdio_container(command->stdout, _ctx);
+  child_stdio[2] = kk_convert_to_stdio_container(command->stderr, _ctx);
+  options.stdio = child_stdio;
+
+  kk_uv_process_wrapper_t* wrapper = kk_malloc(sizeof(kk_uv_process_wrapper_t), _ctx);
+  wrapper->on_exit = on_complete; // wrapper now owns the cb
+  options.exit_cb = &kk_uv_process_exit_callback;
+
+  uv_process_t* process = &(wrapper->process); // type-safe noop
+
+  int status = uv_spawn(uvloop(), process, &options);
+
+  // free up options fields & drop command
+  kk_free(options.file, _ctx);
+  kk_free_nt_carray(options.args, _ctx);
+  kk_uv_process__uv_command_drop(kk_command, _ctx);
+
+  // box the wrapper pointer with custom free, and pass it as the value to Uv-process(...) constructor
+  // uses kk_cptr_raw_box on the pointer
+  //
+  // A running process owns its own handle until it's ended + closed. We return a dup
+  // so that if the user drops the handle before execution is complete, the handle won't be
+  // freed before the process ends.
+  kk_uv_process__uv_process kprocess = uv_handle_to_owned_kk_handle(wrapper, kk_uv_process_wrapper_free, process, process);
+  wrapper->kprocess = kprocess;
+
+  if (status < UV_OK) {
+    kk_uv_process__uv_process_drop(kprocess, _ctx);
+    return kk_async_error_from_errno(status, _ctx);
+  } else {
+    return kk_std_core_exn__new_Ok(
+      kk_uv_process__uv_process_box(kk_uv_process__uv_process_dup(kprocess, _ctx), _ctx),
+      _ctx);
+  }
+}
+
+static int kk_uv_proc_pid(kk_uv_process__uv_process process, kk_context_t* _ctx) {
+  kk_uv_process_wrapper_t* wrapper = kk_unbox_process_borrowed(process);
+  return wrapper->process.pid;
+}
+
+static kk_std_core_exn__error kk_uv_proc_signal(kk_uv_process__uv_process process, int32_t kk_signal, kk_context_t* _ctx) {
+  kk_uv_process_wrapper_t* wrapper = kk_unbox_process_borrowed(process);
+  int status = uv_process_kill(&wrapper->process, kk_signal);
+  kk_uv_check_return(status, kk_unit_box(kk_Unit));
+}

--- a/uv/process.kk
+++ b/uv/process.kk
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------
+  Copyright 2025 Tim Cuthbertson.
+
+  This is free software; you can redistribute it and/or modify it under the
+  terms of the Apache License, Version 2.0. A copy of the License can be
+  found in the LICENSE file at the root of this distribution.
+---------------------------------------------------------------------------*/
+
+// A Koka wrapper around the libuv process API
+module uv/process
+
+import uv/utils
+import std/num/int32
+import std/num/int64
+
+extern import
+  c file "inline/process.c"
+
+// A command specification, which can be used to spawn a process
+pub struct uv-command
+  file: string
+  args: list<string>
+  stdin: stdio-stream
+  stdout: stdio-stream
+  stderr: stdio-stream
+
+pub type stdio-stream
+  Stream-ignore
+  // stream-mkpipe // TODO
+  Stream-fd(fd: int32)
+
+// pub fun pipe-stdout(pipe): child-output
+//   Split(Output-to(pipe), Inerhit-output-stream)
+
+// A running process
+// https://docs.libuv.org/en/v1.x/process.html
+pub value struct uv-process { internal: any }
+
+pub alias uv-exit-cb = (status: int64, signal: int32) -> io-noexn ()
+
+pub fun spawn(command: uv-command, on-complete: uv-exit-cb): io uv-process
+  // https://docs.libuv.org/en/v1.x/process.html
+  // Command line arguments. args[0] should be the path to the program.
+  val raw-cmd = command(args = Cons(command.file, command.args))
+  untry(spawn-c(raw-cmd, on-complete))
+
+extern spawn-c(
+  command: uv-command,
+  on-complete: uv-exit-cb
+): io-noexn error<uv-process>
+  c "kk_uv_proc_spawn_c"
+
+pub extern pid(^process: uv-process): int32
+  c "kk_uv_proc_pid"
+
+pub fun signal(^process: uv-process, signal: int32): exn ()
+  process.try-signal(signal).untry
+
+extern try-signal(^process: uv-process, signal: int32): error<()>
+  c "kk_uv_proc_signal"

--- a/uv/signal.kk
+++ b/uv/signal.kk
@@ -41,6 +41,16 @@ pub val sSIGINT = ssSIGINT()
 extern ssSIGINT(): int32
   c inline "SIGINT"
 
+// The sigquit signal
+pub val sSIGQUIT = ssSIGQUIT()
+extern ssSIGQUIT(): int32
+  c inline "SIGQUIT"
+
+// The sigkill signal
+pub val sSIGKILL = ssSIGKILL()
+extern ssSIGKILL(): int32
+  c inline "SIGKILL"
+
 // Start watching for the given signal, calling the callback on the next event loop
 pub fun signal-start(signal: int32, cb: (uv-signal) -> io-noexn ()): io-noexn uv-status-code
   uv-signal-start(uv-signal-init(), cb, signal).status-code


### PR DESCRIPTION
Requires https://github.com/koka-community/std/pull/45

Low level uv/process, plus higher level std/async/process (not sure if it belongs in `std`, but it can easily be moved).

I've had some success running processes, however running the test I do get this, so it's clearly got some bugs still, but raising this to share it:

```
$ koka -e test/std/async/process-test.kk
# ...
success
- ok
failure
mimalloc: error: corrupted free list entry of size 32b at 0x02000006A9A0: value 0xF95E01585E0B4FD4
error  : command failed (exit code -6)
command: /Users/tcuthbertson/.koka/v3.2.3/clang-debug-7c99c1/test_std_async_process_dash_test__main
```