### PR TITLE
Fixes & high level file module

### DIFF
--- a/std/async/async-file.kk
+++ b/std/async/async-file.kk
@@ -27,10 +27,16 @@ type write-mode
   Truncate
   Append
 
+// TODO: promote to core/hnd?
+fun nonrepeatable(action: () -> e a): e a
+  with initially fn(i)
+    debug/assert("nonrepeatable action resumed more than once", i == 0)
+  action()
+
 fun open-raw(path: string, flags: int32, action: uv-file -> <async,io|e> a): <async,io|e> a
   val f = await1(fn(cb) -> uv/open(path, flags, 0.int32, cb)).untry
-  // with finally { await1(fn(cb) -> uv/close(f, cb)).untry }
-  action(f)
+  with finally { await1(fn(cb) -> uv/close(f, cb)).untry }
+  nonrepeatable { action(f) }
 
 pub fun open-read(path: string, action: forall<s> (file-read<s>) -> <async,io|e> a): <async,io|e> a
   open-raw(path, o_RDONLY) fn(f) action(File-read(f))
@@ -71,8 +77,8 @@ pub fun tempfile(action: forall<s> (tempfile<s>) -> <async,io|e> a, name: string
     Nothing -> tempdir()
   val template = base / (name ++ "XXXXXX")
   val (f, path) = await1(fn(cb) -> mkstemp(template.string, cb)).untry
-  with finally { uv/close(f, fn(_) trace("here")) }
-  action(Tempfile(f, path))
+  with finally { await1(fn(cb) -> uv/close(f, cb)).untry }
+  nonrepeatable { action(Tempfile(f, path)) }
 
 pub fun open-rw(path: string, action: forall<s> (file-rw<s>) -> <async,io|e> a,
   write-mode: write-mode = Truncate

--- a/std/async/async-file.kk
+++ b/std/async/async-file.kk
@@ -1,3 +1,5 @@
+module std/async/async-file
+
 import uv/file
 import std/os/env
 import std/os/path
@@ -27,7 +29,7 @@ type write-mode
 
 fun open-raw(path: string, flags: int32, action: uv-file -> <async,io|e> a): <async,io|e> a
   val f = await1(fn(cb) -> uv/open(path, flags, 0.int32, cb)).untry
-  with finally { await1(fn(cb) -> uv/close(f, cb)).untry }
+  // with finally { await1(fn(cb) -> uv/close(f, cb)).untry }
   action(f)
 
 pub fun open-read(path: string, action: forall<s> (file-read<s>) -> <async,io|e> a): <async,io|e> a
@@ -69,7 +71,7 @@ pub fun tempfile(action: forall<s> (tempfile<s>) -> <async,io|e> a, name: string
     Nothing -> tempdir()
   val template = base / (name ++ "XXXXXX")
   val (f, path) = await1(fn(cb) -> mkstemp(template.string, cb)).untry
-  with finally { await1(fn(cb) -> uv/close(f, cb)).untry }
+  with finally { uv/close(f, fn(_) trace("here")) }
   action(Tempfile(f, path))
 
 pub fun open-rw(path: string, action: forall<s> (file-rw<s>) -> <async,io|e> a,

--- a/std/async/async-file.kk
+++ b/std/async/async-file.kk
@@ -85,3 +85,7 @@ pub fun write<f>(file: f, bytes: bytes, ?writable: (f) -> file-write<s>): <async
   val _n = await1(fn(cb) -> write(w.internal, bytes, 0.int64, cb)).untry
   // TODO is n ever less than `bytes` len?
   ()
+
+pub fun fsync<f>(file: f, ?writable: (f) -> file-write<s>): <asyncx> ()
+  val w = writable(file)
+  await1(fn(cb) -> fsync(w.internal, cb)).untry

--- a/std/async/file.kk
+++ b/std/async/file.kk
@@ -1,0 +1,73 @@
+import uv/file
+import std/os/env
+import std/os/path
+import std/async/async
+
+abstract value struct file-read<s::S> { internal: uv-file }
+pub fun read/readable(f: file-read<s>): file-read<s> -> f
+
+abstract value struct file-write<s::S> { internal: uv-file }
+pub fun write/writable(f: file-write<s>): file-write<s> -> f
+
+abstract value struct file-rw<s::S> { internal: uv-file }
+pub fun rw/readable(f: file-rw<s>): file-read<s> -> File-read(f.internal)
+pub fun rw/writable(f: file-rw<s>): file-write<s> -> File-write(f.internal)
+
+abstract value struct tempfile<s::S>
+  internal: uv-file
+  path: string
+
+pub fun path(f: tempfile<_>): string -> f.tempfile/path
+pub fun tmp/readable(f: tempfile<s>): file-read<s> -> File-read(f.internal)
+pub fun tmp/writable(f: tempfile<s>): file-write<s> -> File-write(f.internal)
+
+type write-mode
+  Truncate
+  Append
+
+fun open-raw(path: string, flags: int32, action: uv-file -> <async,io|e> a): <async,io|e> a
+  val f = await1(fn(cb) -> uv/open(path, flags, 0.int32, cb)).untry
+  with finally { await1(fn(cb) -> uv/close(f, cb)).untry }
+  action(f)
+
+pub fun open-read(path: string, action: forall<s> (file-read<s>) -> <async,io|e> a): <async,io|e> a
+  open-raw(path, o_RDONLY) fn(f) action(File-read(f))
+
+pub fun read<f>(file: f, ?readable: (f) -> file-read<s>): <asyncx> bytes
+  // TODO: keep reading until EOF
+  val r = readable(file)
+  val (bytes, _n) = await1(fn(cb) -> basic/read(r.internal, 2048.int32, cb)).untry
+  bytes
+
+fun write-flags(write-mode: write-mode)
+  o_CREAT.and(match write-mode
+    Truncate -> o_TRUNC
+    Append -> o_APPEND
+  )
+
+pub fun open-write(path: string, action: forall<s> (file-write<s>) -> <async,io|e> a,
+  write-mode: write-mode = Truncate
+): <async,io|e> a
+  var flags := o_RDONLY.and(write-flags(write-mode))
+  open-raw(path, flags) fn(f) action(File-write(f))
+
+pub fun tempfile(action: forall<s> (tempfile<s>) -> <async,io|e> a, name: string = "tmp-", dir: maybe<string> = Nothing): <async,io|e> a
+  val base = match dir
+    Just(d) -> path(d)
+    Nothing -> tempdir()
+  val template = base / (name ++ "XXXXXX")
+  val (f, path) = await1(fn(cb) -> mkstemp(template.string, cb)).untry
+  with finally { await1(fn(cb) -> uv/close(f, cb)).untry }
+  action(Tempfile(f, path))
+
+pub fun open-rw(path: string, action: forall<s> (file-rw<s>) -> <async,io|e> a,
+  write-mode: write-mode = Truncate
+): <async,io|e> a
+  var flags := o_RDWR.and(write-flags(write-mode))
+  open-raw(path, flags) fn(f) action(File-rw(f))
+
+pub fun write<f>(file: f, bytes: bytes, ?writable: (f) -> file-write<s>): <asyncx> ()
+  val w = writable(file)
+  val _n = await1(fn(cb) -> write(w.internal, bytes, 0.int64, cb)).untry
+  // TODO is n ever less than `bytes` len?
+  ()

--- a/std/async/file.kk
+++ b/std/async/file.kk
@@ -33,11 +33,23 @@ fun open-raw(path: string, flags: int32, action: uv-file -> <async,io|e> a): <as
 pub fun open-read(path: string, action: forall<s> (file-read<s>) -> <async,io|e> a): <async,io|e> a
   open-raw(path, o_RDONLY) fn(f) action(File-read(f))
 
-pub fun read<f>(file: f, ?readable: (f) -> file-read<s>): <asyncx> bytes
-  // TODO: keep reading until EOF
+pub fun read<f>(file: f, ?readable: (f) -> file-read<s>): <async,io> bytes
   val r = readable(file)
-  val (bytes, _n) = await1(fn(cb) -> basic/read(r.internal, 2048.int32, cb)).untry
-  bytes
+  var result: bytes := empty()
+  while {
+    match read-chunk(r)
+      Just(chunk) ->
+        result := result ++ chunk
+        True
+      Nothing -> False
+  } { () }
+  result
+
+val current-offset = -1.int32
+
+fun read-chunk<s>(f: file-read<s>): <asyncx> maybe<bytes>
+  val (bytes, n) = await1(fn(cb) -> uv/read(f.internal, 1024.int32, offset = current-offset, cb = cb)).untry
+  if n == 0 /* EOF */ then Nothing else Just(bytes)
 
 fun write-flags(write-mode: write-mode)
   o_CREAT.and(match write-mode

--- a/test/std/async/file-test.kk
+++ b/test/std/async/file-test.kk
@@ -1,6 +1,6 @@
 import std/test
 import std/async/async
-import std/async/file
+import std/async/async-file
 import uv/event-loop
 import std/core/bytes
 import std/core/int

--- a/test/std/async/file-test.kk
+++ b/test/std/async/file-test.kk
@@ -1,0 +1,34 @@
+import std/test
+import std/async/async
+import std/async/file
+import uv/event-loop
+import std/core/bytes
+import std/core/int
+
+fun main(): io-noexn ()
+  with default-event-loop
+  with async/handle
+  run-tests(suite)
+
+fun suite(): <async,test<<io,async>>> ()
+  val contents = "hello, world!"
+
+  // effectful-test("write & read a file")
+  //   val path = "/tmp/kktest-1"
+  //   open-write(path) fn(f)
+  //     f.write(contents.bytes)
+
+  //   expect(contents)
+  //     open-read(path) fn(f)
+  //       f.read().string()
+
+  effectful-test("tempfile")
+    println("start")
+    val (_path, file-contents) = tempfile(name="mytmp-") fn(f)
+      println("file at " ++ f.path ++ "...")
+      f.write(contents.bytes)
+      println("reading...")
+      (f.path, f.read())
+
+    expect(contents) { file-contents.string }
+    // expect(path) { "TODO" }

--- a/test/std/async/file-test.kk
+++ b/test/std/async/file-test.kk
@@ -13,22 +13,15 @@ fun main(): io-noexn ()
 fun suite(): <async,test<<io,async>>> ()
   val contents = "hello, world!"
 
-  // effectful-test("write & read a file")
-  //   val path = "/tmp/kktest-1"
-  //   open-write(path) fn(f)
-  //     f.write(contents.bytes)
-
-  //   expect(contents)
-  //     open-read(path) fn(f)
-  //       f.read().string()
-
   effectful-test("tempfile")
-    println("start")
-    val (_path, file-contents) = tempfile(name="mytmp-") fn(f)
-      println("file at " ++ f.path ++ "...")
+    val (path, file-contents) = tempfile(name="mytmp-") fn(f)
       f.write(contents.bytes)
-      println("reading...")
-      (f.path, f.read())
+      f.fsync()
 
-    expect(contents) { file-contents.string }
-    // expect(path) { "TODO" }
+      // read via the handle itself and also by reopening its path
+      val from-tmp = f.read().string
+      val from-new = open-read(f.path) fn(r) -> r.read().string
+      (f.path, (from-tmp, from-new))
+
+    expect((contents, contents)) { file-contents }
+    expect(True) { path.contains("mytmp-") }

--- a/uv/inline/file.c
+++ b/uv/inline/file.c
@@ -93,9 +93,8 @@ static void kk_std_os_file_buff_cb(uv_fs_t* req) {
     kk_bytes_drop(bytes, _ctx);
     kk_uv_error_callback(callback, result)
   } else {
-    kk_bytes_t btsadj = kk_bytes_adjust_length(bytes, (kk_ssize_t)result + 1, _ctx);
-    kk_bytes_set(btsadj, (uint64_t)result, (int8_t)'\0', _ctx);
-    // TODO?: Maybe would be better to not add a terminating null byte, and fix it when converting to a string instead?
+    // Shrink the returned buffer to what was actually read
+    kk_bytes_t btsadj = kk_bytes_adjust_length(bytes, (kk_ssize_t)result, _ctx);
     kk_std_core_types__tuple2 tuple = kk_std_core_types__new_Tuple2(kk_bytes_box(btsadj), kk_integer_box(kk_integer_from_ssize_t(result, _ctx), _ctx), _ctx); /*(1004, 1005)*/
     kk_box_t tupleboxed = kk_std_core_types__tuple2_box(tuple, _ctx);
     kk_uv_okay_callback(callback, tupleboxed)


### PR DESCRIPTION
I'm still toying with the high level file structure. I went with a scoped _value_ (`file<s>`), since I don't quite understand the benefit of a scoped named effect (which is what the docs mostly seem to use).

Also I've used implicits to expose "readable" & "writable", so that we can have e.g. a read-write file which has both, but if you open a file for reading you can't call any write methods.